### PR TITLE
subtract execution time from next execution

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,15 @@ function runEvery(repeatWaitSeconds, command, process) {
   inner();
 
   function inner() {
+    var start = Date.now();
     proc = spawn(command[0], command.slice(1), { stdio: 'inherit' });
     proc.on('exit', function (code, signal) {
-
+      var finished = Date.now();
       if (code === 0 && signal === null) {
-        timeout = setTimeout(inner, repeatWaitSeconds * 1000);
+        var took = finished - start;
+        var next = repeatWaitSeconds * 1000 - took;
+        if (next <= 0) next = 0;
+        timeout = setTimeout(inner, next);
       } else {
         process.kill(process.pid, signal);
       }


### PR DESCRIPTION
Hi, I use this module for cron-like tasks, but noticed my jobs' start time slowly shifts over time (e.g. run-every 86400). To fix this, this patch changes the behavior from this:

```
🐈  run-every 1 sh -c "sleep 1 && date"
Mon Oct 23 18:00:46 CEST 2017
Mon Oct 23 18:00:48 CEST 2017
Mon Oct 23 18:00:50 CEST 2017
Mon Oct 23 18:00:52 CEST 2017
```

to this

```
🐈  run-every 1 sh -c "sleep 1 && date"
Mon Oct 23 18:01:14 CEST 2017
Mon Oct 23 18:01:15 CEST 2017
Mon Oct 23 18:01:16 CEST 2017
Mon Oct 23 18:01:17 CEST 2017
```